### PR TITLE
Fix build warnings and include diagnostic sources

### DIFF
--- a/Application/Services/MediaIndexingService.cs
+++ b/Application/Services/MediaIndexingService.cs
@@ -73,7 +73,7 @@ namespace TrialWorld.Application.Services
                             Confidence = (float)(s?.Confidence ?? 0)
                         }).ToList() 
                         : new List<SearchableTimestamp>(),
-                    Metadata = metadata.Metadata ?? new Dictionary<string, string>()
+                    Metadata = metadata?.Metadata ?? new Dictionary<string, string>()
                 };
 
                 if (metadata?.FilePath != null && !string.IsNullOrEmpty(metadata.FilePath) && content.Metadata != null)

--- a/Core/Models/Transcription/TranscriptionSegment.cs
+++ b/Core/Models/Transcription/TranscriptionSegment.cs
@@ -6,7 +6,7 @@ namespace TrialWorld.Core.Transcription
     public class TranscriptionSegment
     {
         [JsonPropertyName("text")]
-        public string Text { get; set; }
+        public string Text { get; set; } = string.Empty;
 
         [JsonPropertyName("start")]
         public int Start { get; set; } // Start timestamp in milliseconds
@@ -18,9 +18,9 @@ namespace TrialWorld.Core.Transcription
         public float Confidence { get; set; }
 
         [JsonPropertyName("speaker")]
-        public string Speaker { get; set; }
+        public string Speaker { get; set; } = string.Empty;
 
         [JsonPropertyName("sentiment")]
-        public string Sentiment { get; set; } // e.g., "POSITIVE", "NEGATIVE", "NEUTRAL"
+        public string Sentiment { get; set; } = string.Empty; // e.g., "POSITIVE", "NEGATIVE", "NEUTRAL"
     }
 }

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -6,6 +6,13 @@
     <ProjectReference Include="..\Persistence\Persistence.csproj" />
   </ItemGroup>
 
+  <!-- Include legacy diagnostic files for AssemblyAI integration -->
+  <ItemGroup>
+    <Compile Include="..\Configuration\AssemblyAIOptions.cs" Link="Configuration\AssemblyAIOptions.cs" />
+    <Compile Include="..\Services\*.cs" Link="LegacyServices\%(Filename)%(Extension)" />
+    <Compile Include="..\Repositories\TranscriptionRepository.cs" Link="LegacyRepositories\TranscriptionRepository.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.6.6" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />

--- a/Persistence/Repositories/TranscriptRepository.cs
+++ b/Persistence/Repositories/TranscriptRepository.cs
@@ -53,7 +53,7 @@ namespace TrialWorld.Persistence.Repositories
                 Text = entity.Text ?? string.Empty,
                 Confidence = entity.Confidence,
                 Speaker = entity.SpeakerLabel ?? string.Empty,
-                Sentiment = entity.SentimentScore?.ToString()
+                Sentiment = entity.SentimentScore?.ToString() ?? string.Empty
                 // Words is not in entity, so it will be null
             };
         }
@@ -250,7 +250,7 @@ namespace TrialWorld.Persistence.Repositories
                     Text = entity.Text ?? string.Empty,
                     Confidence = entity.Confidence,
                     Speaker = entity.SpeakerLabel ?? string.Empty,
-                    Sentiment = entity.SentimentScore?.ToString()
+                    Sentiment = entity.SentimentScore?.ToString() ?? string.Empty
                     // Words is not in entity
                 }).ToList();
                 
@@ -336,10 +336,10 @@ namespace TrialWorld.Persistence.Repositories
                     MediaId = entity.MediaId,
                     StartTime = entity.StartTime.TotalMilliseconds,
                     EndTime = entity.EndTime.TotalMilliseconds,
-                    Text = entity.Text,
+                    Text = entity.Text ?? string.Empty,
                     Confidence = entity.Confidence,
-                    Speaker = entity.SpeakerLabel,
-                    Sentiment = entity.SentimentScore?.ToString()
+                    Speaker = entity.SpeakerLabel ?? string.Empty,
+                    Sentiment = entity.SentimentScore?.ToString() ?? string.Empty
                     // Words is not in entity
                 }).ToList();
             }
@@ -369,10 +369,10 @@ namespace TrialWorld.Persistence.Repositories
                 MediaId = entity.MediaId,
                 StartTime = entity.StartTime.TotalMilliseconds,
                 EndTime = entity.EndTime.TotalMilliseconds,
-                Text = entity.Text,
+                Text = entity.Text ?? string.Empty,
                 Confidence = entity.Confidence,
-                Speaker = entity.SpeakerLabel,
-                Sentiment = entity.SentimentScore?.ToString()
+                Speaker = entity.SpeakerLabel ?? string.Empty,
+                Sentiment = entity.SentimentScore?.ToString() ?? string.Empty
                 // Words is not in entity
             }).ToList();
         }
@@ -416,10 +416,10 @@ namespace TrialWorld.Persistence.Repositories
                     MediaId = entity.MediaId,
                     StartTime = entity.StartTime.TotalMilliseconds,
                     EndTime = entity.EndTime.TotalMilliseconds,
-                    Text = entity.Text,
+                    Text = entity.Text ?? string.Empty,
                     Confidence = entity.Confidence,
-                    Speaker = entity.SpeakerLabel,
-                    Sentiment = entity.SentimentScore?.ToString()
+                    Speaker = entity.SpeakerLabel ?? string.Empty,
+                    Sentiment = entity.SentimentScore?.ToString() ?? string.Empty
                     // Words is not in entity
                 }).ToList();
             }
@@ -458,10 +458,10 @@ namespace TrialWorld.Persistence.Repositories
                     MediaId = entity.MediaId,
                     StartTime = entity.StartTime.TotalMilliseconds,
                     EndTime = entity.EndTime.TotalMilliseconds,
-                    Text = entity.Text,
+                    Text = entity.Text ?? string.Empty,
                     Confidence = entity.Confidence,
-                    Speaker = entity.SpeakerLabel,
-                    Sentiment = entity.SentimentScore?.ToString()
+                    Speaker = entity.SpeakerLabel ?? string.Empty,
+                    Sentiment = entity.SentimentScore?.ToString() ?? string.Empty
                     // Words is not in entity
                 }).ToList();
             }


### PR DESCRIPTION
## Summary
- include legacy diagnostic files in Infrastructure project
- initialize text properties to avoid null warnings
- avoid null dereference in MediaIndexingService
- guard mapping conversions in TranscriptRepository

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*